### PR TITLE
Introduce samples for illegal instructions and unhandled traps

### DIFF
--- a/Makefile.frag
+++ b/Makefile.frag
@@ -47,7 +47,9 @@ BP_TESTS_C = \
   uncached_mode_test    \
   amo_nonblocking       \
   amo_interrupt         \
-  divide_hazard
+  divide_hazard         \
+  illegal_instruction   \
+  unhandled_trap
 
 BP_TESTS_CPP = \
   virtual               \

--- a/src/illegal_instruction.c
+++ b/src/illegal_instruction.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include "bp_utils.h"
+
+// This test triggers an illegal instruction exception. Correct behavior under
+// perch is to print a message of the following form, before finishing:
+//
+// mcause: 0x0000000000000002
+// mtval:  0x0000000000000000
+// mepc:   0x000000008effefec
+// Illegal instruction
+
+int main(int argc, char** argv) {
+    int x = 0xDEADBEEF;
+    ((void (*)(void))&x)();
+
+    // Should not get here
+    bp_finish(1);
+
+    return 0;
+}

--- a/src/illegal_instruction.c
+++ b/src/illegal_instruction.c
@@ -8,6 +8,9 @@
 // mtval:  0x0000000000000000
 // mepc:   0x000000008effefec
 // Illegal instruction
+//
+// This test is intended to fail ([CORE0 FSH] FAIL) as this is the desired
+// outcome for normal programs in the case of an illegal instruction.
 
 int main(int argc, char** argv) {
     int x = 0xDEADBEEF;

--- a/src/unhandled_trap.c
+++ b/src/unhandled_trap.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include "bp_utils.h"
+
+// This test triggers a load access fault by reading an invalid address. Correct
+// behavior under perch is to print a message of the following form, before
+// finishing:
+//
+// mcause: 0x0000000000000005
+// mtval:  0x0000007fffffffff
+// mepc:   0x000000008000019c
+// Unhandled machine-mode trap
+
+int main(int argc, char** argv) {
+    *(volatile int*)0xFFFFFFFFFFFFFFFF;
+
+    // Should not get here
+    bp_finish(1);
+
+    return 0;
+}

--- a/src/unhandled_trap.c
+++ b/src/unhandled_trap.c
@@ -9,6 +9,9 @@
 // mtval:  0x0000007fffffffff
 // mepc:   0x000000008000019c
 // Unhandled machine-mode trap
+//
+// This test is intended to fail ([CORE0 FSH] FAIL) as this is the desired
+// outcome for normal programs in the case of an unhandled trap.
 
 int main(int argc, char** argv) {
     *(volatile int*)0xFFFFFFFFFFFFFFFF;


### PR DESCRIPTION
This is a sister PR to https://github.com/black-parrot-sdk/perch/pull/2. As suggested over there, I've added test-cases for the new behavior. Sorry it took a few weeks -- I was running into build problems that I didn't have the patience to look into for real until recently.

Correct operation of the "illegal instruction" case gives:

```
NBF loader done!
mcause: 0x0000000000000002
mtval:  0x0000000000000000
mepc:   0x000000008effefec
Illegal instruction
[CORE0 FSH] FAIL
```

And similarly, for the "unhandled trap" case:

```
NBF loader done!
mcause: 0x0000000000000002
mtval:  0x0000000000000000
mepc:   0x000000008effefec
Illegal instruction
[CORE0 FSH] FAIL
```

Since `bp_panic` invokes `bp_finish` with code `1`, these print "FAIL", but that is intended behavior.