### PR TITLE
mc tests: modify return and finish for threads

### DIFF
--- a/src/mc_rand_walk.c
+++ b/src/mc_rand_walk.c
@@ -137,9 +137,6 @@ uint64_t main(uint64_t argc, char * argv[]) {
   if (core_id == 0) {
     // wait for all threads to finish
     while (end_barrier_mem != NUM_CORES) { }
-    bp_finish(0);
-  } else {
-    bp_finish(0);
   }
 
   return 0;

--- a/src/mc_sanity.c
+++ b/src/mc_sanity.c
@@ -37,11 +37,8 @@ uint64_t main(uint64_t argc, char * argv[]) {
       sum += MATRIX[i*NUM_CORES + core_id];
     }
 
-    if (sum == K) {
-      bp_finish(0);
-    } else {
-      bp_finish(1);
+    if (sum != K) {
+      return 1;
     }
-
     return 0;
 }

--- a/src/mc_work_share_sort.c
+++ b/src/mc_work_share_sort.c
@@ -125,9 +125,6 @@ uint64_t main(uint64_t argc, char * argv[]) {
   if (core_id == 0) {
     // wait for all threads to finish
     while (end_barrier_mem != NUM_CORES) { }
-    bp_finish(0);
-  } else {
-    bp_finish(0);
   }
 
   return 0;


### PR DESCRIPTION
This PR modifies the termination of the multicore sample programs so that each thread/core of BP will only send a finish store to the host once, when the thread returns from main.