### PR TITLE
update multicore test programs to use aviary ROM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,17 +29,5 @@ paging.riscv: vm_start.S paging.c
 mapping.riscv: vm_start.S mapping.c
 	$(RISCV_GCC) -o $@ $^ $(RISCV_GCC_OPTS) $(RISCV_LINK_OPTS) -nostartfiles
 
-mc_sanity_%.riscv: mc_sanity.c
-	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -o $@ $^ $(RISCV_GCC_OPTS) $(RISCV_LINK_OPTS)
-
-mc_template_%.riscv: mc_template.c
-	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -o $@ $^ $(RISCV_GCC_OPTS) $(RISCV_LINK_OPTS)
-
-mc_rand_walk_%.riscv: mc_rand_walk.c
-	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -o $@ $^ $(RISCV_GCC_OPTS) $(RISCV_LINK_OPTS)
-
-mc_work_share_sort_%.riscv: mc_work_share_sort.c
-	$(RISCV_GCC) -DNUM_CORES=$(notdir $*) -o $@ $^ $(RISCV_GCC_OPTS) $(RISCV_LINK_OPTS)
-
 clean:
 	rm -f *.riscv

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -5,32 +5,10 @@ BP_TESTS_C = \
   streaming_accelerator_zipline\
   coherent_accelerator_demo\
   copy_example          \
-  mc_sanity_1           \
-  mc_sanity_2           \
-  mc_sanity_3           \
-  mc_sanity_4           \
-  mc_sanity_6           \
-  mc_sanity_8           \
-  mc_sanity_12          \
-  mc_sanity_16          \
-  mc_template_1         \
-  mc_template_2         \
-  mc_rand_walk_1        \
-  mc_rand_walk_2        \
-  mc_rand_walk_3        \
-  mc_rand_walk_4        \
-  mc_rand_walk_6        \
-  mc_rand_walk_8        \
-  mc_rand_walk_12       \
-  mc_rand_walk_16       \
-  mc_work_share_sort_1  \
-  mc_work_share_sort_2  \
-  mc_work_share_sort_3  \
-  mc_work_share_sort_4  \
-  mc_work_share_sort_6  \
-  mc_work_share_sort_8  \
-  mc_work_share_sort_12 \
-  mc_work_share_sort_16 \
+  mc_sanity             \
+  mc_template           \
+  mc_rand_walk          \
+  mc_work_share_sort    \
   cache_hammer          \
   jalr_illegal          \
   satp_nofence          \

--- a/src/mc_sanity.c
+++ b/src/mc_sanity.c
@@ -8,38 +8,36 @@
  *   system to transfer blocks between the cores as a basic sanity check of coherence
  *   functionality in a multicore system.
  *
+ *   MATRIX_SIZE defines the maximum size of the data matrix used in the test.
+ *   N defines the number of matrix elements accessed per core.
+ *   Constraint: N * num_cores <= MATRIX_SIZE
  */
 
 #include <stdint.h>
 #include "bp_utils.h"
 #include "mc_util.h"
+#include "aviary.h"
 
-#ifndef NUM_CORES
-#define NUM_CORES 2
+#ifndef MATRIX_SIZE
+#define MATRIX_SIZE 8192
 #endif
 
-#define K 512
-
 #ifndef N
-#define N (NUM_CORES*K)
+#define N 512
 #endif
 
 volatile uint64_t __attribute__((aligned(64))) global_lock = 0;
 volatile uint64_t __attribute__((aligned(64))) start_barrier_mem = 0;
 volatile uint64_t __attribute__((aligned(64))) end_barrier_mem = 0;
 
-typedef uint64_t matrix[N];
+typedef uint64_t matrix[MATRIX_SIZE];
 matrix MATRIX;
 
-uint64_t thread_main() {
-  uint64_t core_id;
-  __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
-
-  uint64_t i;
+uint64_t thread_main(uint64_t core_id, uint32_t num_cores, uint32_t iterations) {
   uint64_t sum = 0;
-  for (int i = 0; i < K; i++) {
-    MATRIX[i*NUM_CORES + core_id] = 1;
-    sum += MATRIX[i*NUM_CORES + core_id];
+  for (int i = 0; i < iterations; i++) {
+    MATRIX[i*num_cores + core_id] = 1;
+    sum += MATRIX[i*num_cores + core_id];
   }
 
   // synchronize at end of computation by incrementing the end barrier
@@ -53,20 +51,25 @@ uint64_t thread_main() {
 uint64_t main(uint64_t argc, char * argv[]) {
   uint64_t core_id;
   __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
+  uint32_t num_cores = bp_param_get(PARAM_CC_X_DIM) * bp_param_get(PARAM_CC_Y_DIM);
+  // fail if matrix is too small
+  if (N*num_cores > MATRIX_SIZE) {
+    return 1;
+  }
 
   // all threads execute
-  uint64_t sum = thread_main();
+  uint64_t sum = thread_main(core_id, num_cores, N);
 
   if (core_id == 0) {
     // core 0 waits for all threads to finish
     // wait for all threads to finish
-    while (end_barrier_mem != NUM_CORES) { }
-    if (sum != K) {
+    while (end_barrier_mem != num_cores) { }
+    if (sum != (uint64_t)N) {
       return 1;
     }
     return 0;
   } else {
-    if (sum != K) {
+    if (sum != (uint64_t)N) {
       bp_finish(1);
     } else {
       bp_finish(0);

--- a/src/mc_work_share_sort.c
+++ b/src/mc_work_share_sort.c
@@ -4,6 +4,10 @@
  *
  * Description:
  *   This program utilizes many cores to cooperatively sort a collection of arrays.
+ *   The backing data is defined in mc_data.h and is an array of uint32_t elements with length
+ *   of DATA_LEN. This array, called DATA, is treated as a collection of uint32_t arrays that
+ *   will be sorted by the cores. Each core requests an array to sort, sorts it, then repeats
+ *   until all available arrays have been sorted.
  *
  */
 
@@ -12,27 +16,28 @@
 #include "bp_utils.h"
 #include "mc_util.h"
 #include "mc_data.h"
-
-#ifndef NUM_CORES
-#define NUM_CORES 2
-#endif
+#include "aviary.h"
 
 // DATA_LEN define from "mc_data.h" gives total number of elements in DATA array
 
 // Length of each array
-// This should be set such that an array evenly fills one or more 64-byte cache blocks
+// This should be set such that an array evenly fills one or more cache blocks
 // There are 16 32-bit values in each 512-bit cache block
-#ifndef ARR_LEN
-#define ARR_LEN 32
+// ARRAY_LEN of 32 allows 2048 arrays in default DATA array
+#ifndef ARRAY_LEN
+#define ARRAY_LEN 32
 #endif
 
-// Number of arrays
-// This should be equal to or less than DATA_LEN/ARR_LEN
-// e.g., 65536/64 = 1024 64-element arrays
-#ifndef N
-#define N 32
+// Number of arrays to sort per core
+// This determines the total number of arrays that will be sorted, and each core will sort
+// approximately ARRAYS_PER_CORE, however the number actually sorted per core depends on
+// the dynamic execution, as each core sorts arrays until there are no more arrays left to be
+// sorted from the global pool.
+// num_cores * ARRAYS_PER_CORE * ARRAY_LEN <= DATA_LEN is required
+// ARRAY_LEN of 32 and ARRAYS_PER_CORE of 32 = 1024 array elements per core => maximum of 64 cores
+#ifndef ARRAYS_PER_CORE
+#define ARRAYS_PER_CORE 32
 #endif
-
 
 // global variables written only by core 0
 volatile uint64_t __attribute__((aligned(64))) start_barrier_mem = 0;
@@ -52,8 +57,8 @@ void swap(uint32_t *x, uint32_t * y) {
 
 void sortArray(uint32_t *array) {
   // bubble sort because we want the core to do work :)
-  for (int i = 0; i < ARR_LEN-1; i++) {
-    for (int j = 0; j < ARR_LEN-i-1; j++) {
+  for (int i = 0; i < ARRAY_LEN-1; i++) {
+    for (int j = 0; j < ARRAY_LEN-i-1; j++) {
       if (array[j] > array[j+1]) {
         swap(&array[j], &array[j+1]);
       }
@@ -61,15 +66,15 @@ void sortArray(uint32_t *array) {
   }
 }
 
-uint32_t getNextArray(uint32_t **array) {
+uint32_t getNextArray(uint32_t **array, uint32_t total_arrays) {
   uint64_t local_read_count;
   lock(&global_lock);
-  if (read_count < N) {
+  if (read_count < total_arrays) {
     local_read_count = read_count;
     *array = &DATA[read_index];
     // ARRAYS is a one-dimensional array, which we treat as a two-dimensional array
     // increment the read_index by the length of each sub-array
-    read_index += ARR_LEN;
+    read_index += ARRAY_LEN;
     read_count += 1;
     unlock(&global_lock);
     return local_read_count;
@@ -79,13 +84,10 @@ uint32_t getNextArray(uint32_t **array) {
   return 0;
 }
 
-uint64_t thread_main() {
-  uint64_t core_id;
-  __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
-
+uint64_t thread_main(uint32_t total_arrays) {
   while (1) {
     uint32_t *array = NULL;
-    uint32_t arr_index = getNextArray(&array);
+    uint32_t arr_index = getNextArray(&array, total_arrays);
     if (array) {
       sortArray(array);
     } else {
@@ -103,6 +105,13 @@ uint64_t thread_main() {
 uint64_t main(uint64_t argc, char * argv[]) {
   uint64_t core_id;
   __asm__ volatile("csrr %0, mhartid": "=r"(core_id): :);
+  uint32_t num_cores = bp_param_get(PARAM_CC_X_DIM) * bp_param_get(PARAM_CC_Y_DIM);
+  // fail if number of arrays to sort requires more data than is available
+  uint32_t total_arrays = ARRAYS_PER_CORE*num_cores;
+  uint32_t total_array_len = total_arrays*ARRAY_LEN;
+  if (total_array_len > DATA_LEN) {
+    return 1;
+  }
 
   // only core 0 intializes data structures
   if (core_id == 0) {
@@ -119,12 +128,12 @@ uint64_t main(uint64_t argc, char * argv[]) {
   }
 
   // all threads execute
-  thread_main();
+  thread_main(total_arrays);
 
   if (core_id == 0) {
     // core 0 waits for all threads to finish
     // wait for all threads to finish
-    while (end_barrier_mem != NUM_CORES) { }
+    while (end_barrier_mem != num_cores) { }
     return 0;
   } else {
     bp_finish(0);


### PR DESCRIPTION
This change updates the baremetal multicore tests to use the aviary ROM to determine number of cores in the system. This removes  the requirement to compile unique versions of the programs per hardware configuration and greatly simplifies the multicore test framework.