### PR TITLE
Fixing nonblocking AMO and aviary rom tests

### DIFF
--- a/src/amo_nonblocking.c
+++ b/src/amo_nonblocking.c
@@ -5,8 +5,19 @@
 uint64_t amo_target __attribute__ ((aligned (16))) = 0;
 
 void main(uint64_t argc, char * argv[]) {
-  for (int i = 0; i < 10000; i++) {
-    __asm__ __volatile__ ("amoadd.d x0, %0, 0(%1)" : : "r" (1), "r" (&amo_target));
+  for (int i = 0; i < 1000; i++) {
+    uint64_t amo_target_addr = &amo_target;
+    __asm__ __volatile__ ("amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1); \
+                           amoadd.d x0, %0, 0(%1);"
+                           : : "r" (1), "r" (amo_target_addr));
   }
 
   if (amo_target == 10000) {

--- a/src/aviary_rom.c
+++ b/src/aviary_rom.c
@@ -47,9 +47,9 @@ int main(uint64_t argc, char * argv[]) {
     if (bp_param_get(PARAM_DTLB_ELS_1G) != 0) return -1;
 
     if (bp_param_get(PARAM_LR_SC)                != 1) return -1;
-    if (bp_param_get(PARAM_AMO_SWAP)             != 0) return -1;
-    if (bp_param_get(PARAM_AMO_FETCH_LOGIC)      != 0) return -1;
-    if (bp_param_get(PARAM_AMO_FETCH_ARITHMETIC) != 0) return -1;
+    if (bp_param_get(PARAM_AMO_SWAP)             != 1) return -1;
+    if (bp_param_get(PARAM_AMO_FETCH_LOGIC)      != 1) return -1;
+    if (bp_param_get(PARAM_AMO_FETCH_ARITHMETIC) != 1) return -1;
 
     if (bp_param_get(PARAM_L1_WRITETHROUGH)    != 0  ) return -1;
     if (multicore) {


### PR DESCRIPTION
This PR is intended to support enabling L1 amos in BP unicore.  It fixes the nonblocking AMO test to constantly send AMOs by unrolling the loop. It also updates the aviary rom test to support L1 AMO configs