### PR TITLE
Add copy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ RISCV_GPP           = $(CROSS_COMPILE)g++
 RISCV_GCC_OPTS      = -march=rv64imafd -mabi=lp64 -mcmodel=medany -I$(BP_SDK_INCLUDE_DIR)
 RISCV_LINK_OPTS     = -T$(BP_SDK_LINKER_DIR)/riscv.ld -L$(BP_SDK_LIB_DIR) -Wl,--whole-archive -lperchbm -Wl,--no-whole-archive
 
+COPY_SOURCE = $(BP_SDK_DIR)/bp-tests/*.riscv
+COPY_DEST   = $(BP_SDK_PROG_DIR)/bp-tests
+
 .PHONY: all
+.PHONY: copy
 
 vpath %.c   ./src
 vpath %.cpp ./src
@@ -44,3 +48,5 @@ coherent_accelerator_vdp.riscv: coherent_accelerator_vdp.c vdp.c
 clean:
 	rm -f *.riscv
 
+copy: 
+	cp $(COPY_SOURCE) $(COPY_DEST)


### PR DESCRIPTION
This target could improve workflow when designing test programs. So that you don't have to manually copy the compiled files.