### PR TITLE
parmeterize march and mabi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 
+WITH_MARCH ?= rv64gc
+WITH_MABI ?= lp64d
+
 include Makefile.frag
 
 RISCV_GCC           = $(CROSS_COMPILE)gcc
 RISCV_GPP           = $(CROSS_COMPILE)g++
-RISCV_GCC_OPTS      = -march=rv64gc -mabi=lp64d -mcmodel=medany -I$(BP_SDK_INCLUDE_DIR)
+RISCV_GCC_OPTS      = -march=$(WITH_MARCH) -mabi=$(WITH_MABI) -mcmodel=medany -I$(BP_SDK_INCLUDE_DIR)
 RISCV_LINK_OPTS     = -T$(BP_SDK_LINKER_DIR)/riscv.ld -L$(BP_SDK_LIB_DIR) -Wl,--whole-archive -lperchbm -Wl,--no-whole-archive
 
 .PHONY: all


### PR DESCRIPTION
Add Makefile flags to allow -march and -mabi option override when compiling bp-tests.

BP supports the "C" extension through a parameter and therefore the toolchain should also support a way to compile programs with or without the extension. This change allows the user to specify whether their machine target uses "C" or not.