### PR TITLE
Modify barrier sync used in multicore mc_lrsc_add test

### DIFF
--- a/src/mc_amo_add.c
+++ b/src/mc_amo_add.c
@@ -4,7 +4,7 @@
 #include "mc_util.h"
 
 // N must be multiple of 100
-#define N 100
+#define N 500
 
 #define LOOP_INSTR \
 {                  \

--- a/src/mc_amo_add.c
+++ b/src/mc_amo_add.c
@@ -4,7 +4,7 @@
 #include "mc_util.h"
 
 // N must be multiple of 100
-#define N 500
+#define N 100
 
 #define LOOP_INSTR \
 {                  \

--- a/src/mc_lrsc_add.c
+++ b/src/mc_lrsc_add.c
@@ -4,7 +4,7 @@
 #include "mc_util.h"
 
 // number of iterations for each core to run the main loop
-#define N 500
+#define N 100
 
 volatile uint64_t barrier_mem __attribute__((aligned(64))) = 0;
 volatile uint64_t amo_target __attribute__ ((aligned (64))) = 0;

--- a/src/mc_lrsc_add.c
+++ b/src/mc_lrsc_add.c
@@ -16,7 +16,10 @@ uint64_t main(uint64_t argc, char * argv[]) {
   uint64_t sc_load = 0;
   int i = 0;
 
-  sync_barrier(&barrier_mem);
+  uint64_t barrier_entry = 1;
+
+  sync_barrier(&barrier_mem, barrier_entry);
+  barrier_entry++;
 
   // main loop
   // Execute LR/SC that performs amo_add.d of 1 to amo_target
@@ -36,7 +39,8 @@ uint64_t main(uint64_t argc, char * argv[]) {
     );
 
   // all cores synchronize at end
-  sync_barrier(&barrier_mem);
+  sync_barrier(&barrier_mem, barrier_entry);
+  barrier_entry++;
 
   uint32_t num_cores = bp_param_get(PARAM_CC_X_DIM) * bp_param_get(PARAM_CC_Y_DIM);
   uint64_t total = num_cores * N;

--- a/src/mc_lrsc_add.c
+++ b/src/mc_lrsc_add.c
@@ -4,7 +4,7 @@
 #include "mc_util.h"
 
 // number of iterations for each core to run the main loop
-#define N 100
+#define N 500
 
 volatile uint64_t barrier_mem __attribute__((aligned(64))) = 0;
 volatile uint64_t amo_target __attribute__ ((aligned (64))) = 0;


### PR DESCRIPTION
This PR fixes the sync_barrier function used in the mc_lrsc_add test to avoid a race condition possible where the leader core clears the barrier back to 0 before the other cores observe all cores reaching the barrier, thereby causing one subset of cores to loop forever waiting for the barrier to be reached while the other subset of cores observes it and proceeds.

This PR should be merge squashed.